### PR TITLE
Command event

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -127,6 +127,52 @@ module.exports.Bot = (function() {
     this.password = options.password;
     this.debug = options.debug;
     this.name = options.name;
+
+    // Emit a `command` event.
+    //
+    // A command is either a private message or a message on a channel directed
+    // to the bot starting with '@bot' or 'bot:' (but not just 'bot').
+    //
+    // Listeners are passed:
+    //
+    //   - `message`: the message
+    //   - `reply`: a function to call to reply, passing it a message
+    //
+    // If the command was received on a channel, the bot's name is stripped from
+    // the message and the user's name is added to the response.
+    //
+    // (Not sure what the right place for this would be)
+    this.on('message', function(channel, from, message) {
+      function firstName(name) {
+        return name.split(' ')[0];
+      }
+      
+      var botNick = preg_quote(this.name)+'|'+preg_quote(firstName(this.name));
+      if (m = message.match(new RegExp('^\\s*(@?)('+botNick+')(:?)\\s*(.*)$', 'i'))) {
+        var at = m[1], colon = m[3], message = m[4];
+        
+        if (!at && !colon)
+          return; // maybe just talking about the bot (not aimed at it)
+          
+        var bot = this;
+        this.emit('command', message, function(reply) {
+          // Only use first name for response, so HipChat colors it nicely.
+          bot.message(channel, '@' + firstName(from) + ' ' + reply);
+        });
+      }
+      
+      // Not sure if a native JS function exists somewhere?
+      function preg_quote( str ) {
+        return (str+'').replace(/([\\\.\+\*\?\[\^\]\$\(\)\{\}\=\!\<\>\|\:])/g, "\\$1");
+      }
+    });
+    
+    this.on('privateMessage', function(from, message) {
+      var bot = this;
+      this.emit('command', message, function(reply) {
+        bot.message(from, reply);
+      });
+    });
   };
 
   util.inherits(Bot, events.EventEmitter);


### PR DESCRIPTION
Added the "command" event, which works both on channels as well as privately.

This allows one to simply do:

```
bot.on 'command', (message, reply) ->
    reply 'You told me to "' + message + '"'
```

This will make the bot accept the command both privately as well as on channels, without a separate handler.
