### PR TITLE
Send up identifying information with presence

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -52,7 +52,7 @@ module.exports.Bot = (function() {
 
   // Returns the current version of Wobot
   var getWobotVersion = function() {
-    var packageData = fs.readFileSync('package.json', 'utf8');
+    var packageData = fs.readFileSync(__dirname + '/../package.json', 'utf8');
     return JSON.parse(packageData).version;
   };
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var events = require('events');
+var fs = require('fs');
 var xmpp = require('node-xmpp');
 var bind = require('underscore').bind;
 
@@ -47,6 +48,12 @@ module.exports.Bot = (function() {
       console.log(' OUT > ' + stanza);
       return origSend.call(self.jabber, stanza);
     };
+  };
+
+  // Returns the current version of Wobot
+  var getWobotVersion = function() {
+    var packageData = fs.readFileSync('package.json', 'utf8');
+    return JSON.parse(packageData).version;
   };
 
   // Whenever an XMPP connection is made, this function is responsible for
@@ -113,6 +120,8 @@ module.exports.Bot = (function() {
   //   - `password`: Bot's HipChat password
   //   - `name`: Bot's full name (must match HipChat's data)
   //   - `debug`: Set to `true` to show network debug in console
+  //   - `caps_ver`: Name and version of bot. Override if Wobot is being used
+  //                 to power another bot framework (e.g. Hubot)
   function Bot(options) {
     events.EventEmitter.call(this);
     this.once('connect', function() { }); // listener bug in Node 0.4.2
@@ -127,6 +136,7 @@ module.exports.Bot = (function() {
     this.password = options.password;
     this.debug = options.debug;
     this.name = options.name;
+    this.caps_ver = options.caps_ver || 'wobot:'+getWobotVersion()
   };
 
   util.inherits(Bot, events.EventEmitter);
@@ -163,6 +173,15 @@ module.exports.Bot = (function() {
     if (status) {
       packet.c('status').t(status);
     }
+
+    // Providing capabilities info (XEP-0115) in presence tells HipChat
+    // what type of client is connecting. The rest of the spec is not actually
+    // used at this time.
+    packet.c('c', {
+      xmlns: 'http://jabber.org/protocol/caps',
+      node: 'http://hipchat.com/client/bot', // tell HipChat we're a bot
+      ver: this.caps_ver
+    });
 
     this.jabber.send(packet);
   };


### PR DESCRIPTION
This is a change to take advantage of some new HipChat functionality we'll be rolling out soon; the ability to view active sessions on the website and see some information about them. This change is also compatible with the live HipChat server code.

It basically implements a tiny part of [XEP-0115](http://xmpp.org/extensions/xep-0115.html) in order to tell the server what type of client we (Wobot) are and what version we're running. It allows overriding on initialization so that other bots like Hubot can specify their own version.

Fetching the version # from package.json was suggested by @isaacs in #node.js.
