### PR TITLE
Add method for getting the rooms list

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -138,7 +138,6 @@ module.exports.Bot = (function() {
     this.jabber = null;
     this.keepalive = null;
     this.plugins = {};
-
     this.iq_count = 1; // current IQ id to use
 
     options = options || {};
@@ -147,6 +146,10 @@ module.exports.Bot = (function() {
     this.debug = options.debug;
     this.name = options.name;
     this.host = options.host;
+
+    // Multi-User-Conference (rooms) service host. Use when directing stanzas
+    // to the MUC service.
+    this.mucHost = this.host ? "conf." + this.host : "conf.hichat.com";
   };
 
   util.inherits(Bot, events.EventEmitter);
@@ -168,6 +171,42 @@ module.exports.Bot = (function() {
     this.jabber.on('error', bind(onError, this));
     this.jabber.on('online', bind(onOnline, this));
     this.jabber.on('stanza', bind(onStanza, this));
+  };
+
+  // Fetches the rooms available to the bot user. This is equivalent to what
+  // would show up in the HipChat lobby.
+  //
+  // - `callback`: Function to be triggered: `function (err, items, stanza)`
+  //   - `err`: Error condition (string) if any
+  //   - `rooms`: Array of objects containing room data
+  //   - `stanza`: Full response stanza, an `xmpp.Element`
+  Bot.prototype.getRooms = function(callback) {
+    var getStanza = new xmpp.Element('iq', { to: this.mucHost, type: 'get' })
+                    .c('query', {
+                      xmlns: 'http://jabber.org/protocol/disco#items'
+                    });
+    this.sendIq(getStanza, function(err, stanza) {
+      var rooms = [];
+      if (!err) {
+        // parse response into objects
+        stanza.getChild('query').getChildren('item').map(function(el) {
+          var x = el.getChild('x', 'http://hipchat.com/protocol/muc#room');
+          rooms.push({
+            jid: el.attrs.jid,
+            name: el.attrs.name,
+            id: parseInt(x.getChild('id').getText()),
+            topic: x.getChild('topic').getText(),
+            privacy: x.getChild('privacy').getText(),
+            owner: x.getChild('owner').getText(),
+            num_participants:
+              parseInt(x.getChild('num_participants').getText()),
+            guest_url: x.getChild('guest_url').getText(),
+            is_archived: x.getChild('is_archived') ? true : false
+          });
+        });
+      }
+      callback(err, rooms, stanza);
+    });
   };
 
   // Fetches the roster (buddy list)
@@ -239,8 +278,9 @@ module.exports.Bot = (function() {
   // - `message`: Message to be sent to the room
   Bot.prototype.message = function(targetJid, message) {
     var packet;
+    var parsedJid = new xmpp.JID(targetJid);
 
-    if (targetJid.match(/^(.*)@conf.hipchat.com$/)) {
+    if (parsedJid.domain == this.mucHost) {
       packet = new xmpp.Element('message', {
         to: targetJid + '/' + this.name,
         type: 'groupchat'

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -181,11 +181,9 @@ module.exports.Bot = (function() {
   //   - `rooms`: Array of objects containing room data
   //   - `stanza`: Full response stanza, an `xmpp.Element`
   Bot.prototype.getRooms = function(callback) {
-    var getStanza = new xmpp.Element('iq', { to: this.mucHost, type: 'get' })
-                    .c('query', {
-                      xmlns: 'http://jabber.org/protocol/disco#items'
-                    });
-    this.sendIq(getStanza, function(err, stanza) {
+    var iq = new xmpp.Element('iq', { to: this.mucHost, type: 'get' })
+             .c('query', { xmlns: 'http://jabber.org/protocol/disco#items' });
+    this.sendIq(iq, function(err, stanza) {
       var rooms = [];
       if (!err) {
         // parse response into objects
@@ -216,9 +214,9 @@ module.exports.Bot = (function() {
   //   - `items`: Array of objects containing user data
   //   - `stanza`: Full response stanza, an `xmpp.Element`
   Bot.prototype.getRoster = function(callback) {
-    var getStanza = new xmpp.Element('iq', { type: 'get' })
-                    .c('query', { xmlns: 'jabber:iq:roster' });
-    this.sendIq(getStanza, function(err, stanza) {
+    var iq = new xmpp.Element('iq', { type: 'get' })
+             .c('query', { xmlns: 'jabber:iq:roster' });
+    this.sendIq(iq, function(err, stanza) {
       var rosterItems = [];
       if (!err) {
         // parse response into objects


### PR DESCRIPTION
Pulls the same info that's used to show the data in the Lobby in HipChat clients. I've seen people (and Hubot) hitting the REST API to get the rooms list but this is the right way to do it.
