### PR TITLE
Get room nickname automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ Instantiate the `wobot.Bot` class by passing it a hash containing:
 
   - `jid`: Jabber ID followed by `/bot`
   - `password`: The account's password
-  - `name`: The name of the bot as it appears in HipChat. This is usually `firstname + lastname[0]`.
 
 ```javascript
 var wobot = require('wobot');
 
 var bot = new wobot.Bot({
   jid: '????_????@chat.hipchat.com/bot',
-  password: '??????',
-  name: '???? ????'
+  password: '??????'
 });
 
 bot.connect();

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -5,8 +5,7 @@ var xmpp = require('node-xmpp');
 var b = new Bot({
   debug: true,
   jid: '?_?@chat.hipchat.com/bot',
-  password: '',
-  name: '???? ????'
+  password: ''
 });
 
 b.loadPlugin('chuckjokes', require('./plugins/chuckjokes'));

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -18,9 +18,7 @@ b.onConnect(function() {
   this.join('????_????@conf.hipchat.com');
 
   // fetch and print roster contacts (buddy list) as an IQ get/response example
-  var stanza = new xmpp.Element('iq', { type: 'get' })
-               .c('query', { xmlns: 'jabber:iq:roster' });
-  this.sendIq(stanza, function(result) {
+  this.getRoster(function(result) {
     result.getChild('query').getChildren('item').map(function(el) {
       console.log('Contact: '+el.attrs.name+' ('+ el.attrs.jid + ')');
     });

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -17,10 +17,14 @@ b.onConnect(function() {
   console.log(' -=- > Connect');
   this.join('????_????@conf.hipchat.com');
 
-  // fetch and print roster contacts (buddy list) as an IQ get/response example
-  this.getRoster(function(result) {
-    result.getChild('query').getChildren('item').map(function(el) {
-      console.log('Contact: '+el.attrs.name+' ('+ el.attrs.jid + ')');
+  // fetch and print roster contacts (buddy list)
+  this.getRoster(function(err, items, stanza) {
+    if (err) {
+      console.log(' -=- > Error getting roster: ' + err);
+      return;
+    }
+    items.forEach(function(item) {
+      console.log(' -=- > Roster contact: ' + item.name);
     });
   });
 });

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -1,5 +1,6 @@
 var Bot = require('../lib/').Bot;
 var http = require('http');
+var xmpp = require('node-xmpp');
 
 var b = new Bot({
   debug: true,
@@ -15,6 +16,15 @@ b.connect();
 b.onConnect(function() {
   console.log(' -=- > Connect');
   this.join('????_????@conf.hipchat.com');
+
+  // fetch and print roster contacts (buddy list) as an IQ get/response example
+  var stanza = new xmpp.Element('iq', { type: 'get' })
+               .c('query', { xmlns: 'jabber:iq:roster' });
+  this.sendIq(stanza, function(result) {
+    result.getChild('query').getChildren('item').map(function(el) {
+      console.log('Contact: '+el.attrs.name+' ('+ el.attrs.jid + ')');
+    });
+  });
 });
 
 b.onPing(function() {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -51,7 +51,7 @@ module.exports.Bot = (function() {
 
   // Whenever an XMPP connection is made, this function is responsible for
   // triggering the `connect` event and starting the 30s anti-idle. It will
-  //  also set the availability of the bot to `chat`.
+  // also set the availability of the bot to `chat`.
   var onOnline = function() {
     var self = this;
     this.setAvailability('chat');

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -72,7 +72,6 @@ module.exports.Bot = (function() {
     this.getProfile(function(err, data) {
       if (err) {
         self.emit('error', 'Unable to get profile info: ' + err);
-        self.disconnect();
         return;
       }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -101,8 +101,20 @@ module.exports.Bot = (function() {
 
       this.emit('privateMessage', jid, body.getText());
     } else if (stanza.is('iq')) {
-      // call stored callback function for IQ response
-      this.emit('iq:' + stanza.attrs.id, stanza);
+      // handle a response to an IQ request
+      var event_id = 'iq:' + stanza.attrs.id;
+      if (stanza.attrs.type == 'result') {
+        this.emit(event_id, null, stanza);
+      } else {
+        // IQ error response
+        // ex: http://xmpp.org/rfcs/rfc6121.html#roster-syntax-actions-result
+        var condition = 'unknown';
+        var error_elem = stanza.getChild('error');
+        if (error_elem) {
+          condition = error_elem.children[0].name;
+        }
+        this.emit(event_id, condition, stanza);
+      }
     }
   };
 
@@ -155,10 +167,27 @@ module.exports.Bot = (function() {
   };
 
   // Fetches the roster (buddy list)
+  //
+  // - `callback`: Function to be triggered: `function (err, items, stanza)`
+  //   - `err`: Error condition (string) if any
+  //   - `items`: Array of objects containing user data
+  //   - `stanza`: Full response stanza, an `xmpp.Element`
   Bot.prototype.getRoster = function(callback) {
-    var stanza = new xmpp.Element('iq', { type: 'get' })
-                 .c('query', { xmlns: 'jabber:iq:roster' });
-    this.sendIq(stanza, callback);
+    var getStanza = new xmpp.Element('iq', { type: 'get' })
+                    .c('query', { xmlns: 'jabber:iq:roster' });
+    this.sendIq(getStanza, function(err, stanza) {
+      var rosterItems = [];
+      if (!err) {
+        // parse response into objects
+        stanza.getChild('query').getChildren('item').map(function(el) {
+          rosterItems.push({
+            jid: el.attrs.jid,
+            name: el.attrs.name
+          });
+        });
+      }
+      callback(err, rosterItems, stanza);
+    });
   };
 
   // Updates the bot's availability and status.
@@ -238,6 +267,11 @@ module.exports.Bot = (function() {
 
   // Sends an IQ stanza and stores a callback to be called when its response
   // is received.
+  //
+  // - `stanza`: `xmpp.Element` to send
+  // - `callback`: Function to be triggered: `function (err, stanza)`
+  //   - `err`: Error condition (string) if any
+  //   - `stanza`: Full response stanza, an `xmpp.Element`
   Bot.prototype.sendIq = function(stanza, callback) {
     stanza = stanza.root(); // work with base element
     var id = this.iq_count++;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -63,8 +63,14 @@ module.exports.Bot = (function() {
 
     // load our profile to get name
     this.getProfile(function(err, data) {
-      self.name = data.fn;
+      if (err) {
+        self.emit('error', 'Unable to get profile info: ' + err);
+        self.disconnect();
+        return;
+      }
+
       // now that we have our name we can let rooms be joined
+      self.name = data.fn;
       self.emit('connect');
     });
   };

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -106,6 +106,7 @@ module.exports.Bot = (function() {
       var id = stanza.attrs.id;
       if (id in this.iq_callbacks) {
         this.iq_callbacks[id](stanza);
+        delete this.iq_callbacks[id];
       }
     }
   };

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -102,12 +102,7 @@ module.exports.Bot = (function() {
       this.emit('privateMessage', jid, body.getText());
     } else if (stanza.is('iq')) {
       // call stored callback function for IQ response
-      // TODO: emit some sort of error if the ID is unexpected?
-      var id = stanza.attrs.id;
-      if (id in this.iq_callbacks) {
-        this.iq_callbacks[id](stanza);
-        delete this.iq_callbacks[id];
-      }
+      this.emit('iq:' + stanza.attrs.id, stanza);
     }
   };
 
@@ -131,7 +126,6 @@ module.exports.Bot = (function() {
     this.plugins = {};
 
     this.iq_count = 1; // current IQ id to use
-    this.iq_callbacks = {}; // map of IQ id to callback function
 
     options = options || {};
     this.jid = options.jid;
@@ -158,6 +152,13 @@ module.exports.Bot = (function() {
     this.jabber.on('error', bind(onError, this));
     this.jabber.on('online', bind(onOnline, this));
     this.jabber.on('stanza', bind(onStanza, this));
+  };
+
+  // Fetches the roster (buddy list)
+  Bot.prototype.getRoster = function(callback) {
+    var stanza = new xmpp.Element('iq', { type: 'get' })
+                 .c('query', { xmlns: 'jabber:iq:roster' });
+    this.sendIq(stanza, callback);
   };
 
   // Updates the bot's availability and status.
@@ -241,7 +242,7 @@ module.exports.Bot = (function() {
     stanza = stanza.root(); // work with base element
     var id = this.iq_count++;
     stanza.attrs.id = id;
-    this.iq_callbacks[id] = callback;
+    this.once('iq:' + id, callback);
     this.jabber.send(stanza);
   };
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -53,16 +53,20 @@ module.exports.Bot = (function() {
   // triggering the `connect` event and starting the 30s anti-idle. It will
   //  also set the availability of the bot to `chat`.
   var onOnline = function() {
-    this.setAvailability('chat');
-    this.getMucInfo();
-
     var self = this;
+    this.setAvailability('chat');
+
     this.keepalive = setInterval(function() {
       self.jabber.send(' ');
       self.emit('ping');
     }, 30000);
 
-    this.emit('connect');
+    // load our profile to get name
+    this.getProfile(function(err, data) {
+      self.name = data.fn;
+      // now that we have our name we can let rooms be joined
+      self.emit('connect');
+    });
   };
 
   // This function is responsible for handling incoming XMPP messages. The
@@ -126,7 +130,6 @@ module.exports.Bot = (function() {
   //
   //   - `jid`: Bot's JabberId
   //   - `password`: Bot's HipChat password
-  //   - `name`: Bot's full name (must match HipChat's data)
   //   - `debug`: Set to `true` to show network debug in console
   function Bot(options) {
     events.EventEmitter.call(this);
@@ -135,6 +138,7 @@ module.exports.Bot = (function() {
 
     this.jabber = null;
     this.keepalive = null;
+    this.name = null;
     this.plugins = {};
 
     this.iq_count = 1; // current IQ id to use
@@ -143,7 +147,6 @@ module.exports.Bot = (function() {
     this.jid = options.jid;
     this.password = options.password;
     this.debug = options.debug;
-    this.name = options.name;
   };
 
   util.inherits(Bot, events.EventEmitter);
@@ -166,19 +169,25 @@ module.exports.Bot = (function() {
     this.jabber.on('stanza', bind(onStanza, this));
   };
 
-  // Fetches the required room nickname from the server.
-  // See: http://xmpp.org/extensions/xep-0045.html#reservednick
-  Bot.prototype.getMucInfo = function() {
-    var conf_host = this.host ? 'conf.' + this.host : 'conf.hipchat.com';
-    var stanza = new xmpp.Element('iq', {
-      id: 'getnick',
-      type: 'get',
-      to: conf_host
+  // Fetches our profile info
+  //
+  // - `callback`: Function to be triggered: `function (err, data, stanza)`
+  //   - `err`: Error condition (string) if any
+  //   - `data`: Object containing fields returned (fn, title, photo, etc)
+  //   - `stanza`: Full response stanza, an `xmpp.Element`
+  Bot.prototype.getProfile = function(callback) {
+    var stanza = new xmpp.Element('iq', { type: 'get' })
+                 .c('vCard', { xmlns: 'vcard-temp' });
+    this.sendIq(stanza, function(err, response) {
+      var data = {};
+      if (!err) {
+        var fields = response.getChild('vCard').children;
+        fields.forEach(function(field) {
+          data[field.name.toLowerCase()] = field.getText();
+        });
+      }
+      callback(err, data, response);
     });
-    stanza.c('query', {
-      xmlns: 'http://jabber.org/protocol/disco#info'
-    });
-    this.jabber.send(stanza);
   };
 
   // Fetches the roster (buddy list)

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -50,19 +50,19 @@ module.exports.Bot = (function() {
   };
 
   // Whenever an XMPP connection is made, this function is responsible for
-  // triggering the `connect` event and starting the 30s anti-idle. It will also
-  // set the availability of the bot to `chat`.
+  // triggering the `connect` event and starting the 30s anti-idle. It will
+  //  also set the availability of the bot to `chat`.
   var onOnline = function() {
+    this.setAvailability('chat');
+    this.getMucInfo();
+
     var self = this;
-
-    self.setAvailability('chat');
-
-    self.keepalive = setInterval(function() {
+    this.keepalive = setInterval(function() {
       self.jabber.send(' ');
       self.emit('ping');
     }, 30000);
 
-    self.emit('connect');
+    this.emit('connect');
   };
 
   // This function is responsible for handling incoming XMPP messages. The
@@ -70,8 +70,8 @@ module.exports.Bot = (function() {
   // handling.
   //
   // The bot will parse the message and trigger the `message`
-  // event when it is a group chat message or the `privateMessage` event when it
-  // is a private message.
+  // event when it is a group chat message or the `privateMessage` event when
+  // it is a private message.
   var onStanza = function(stanza) {
     this.emit('data', stanza);
 
@@ -147,6 +147,21 @@ module.exports.Bot = (function() {
     this.jabber.on('error', bind(onError, this));
     this.jabber.on('online', bind(onOnline, this));
     this.jabber.on('stanza', bind(onStanza, this));
+  };
+
+  // Fetches the required room nickname from the server.
+  // See: http://xmpp.org/extensions/xep-0045.html#reservednick
+  Bot.prototype.getMucInfo = function() {
+    var conf_host = this.host ? 'conf.' + this.host : 'conf.hipchat.com';
+    var stanza = new xmpp.Element('iq', {
+      id: 'getnick',
+      type: 'get',
+      to: conf_host
+    });
+    stanza.c('query', {
+      xmlns: 'http://jabber.org/protocol/disco#info'
+    });
+    this.jabber.send(stanza);
   };
 
   // Updates the bot's availability and status.

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -100,6 +100,13 @@ module.exports.Bot = (function() {
       var jid = attrFrom.substring(0, offset);
 
       this.emit('privateMessage', jid, body.getText());
+    } else if (stanza.is('iq')) {
+      // call stored callback function for IQ response
+      // TODO: emit some sort of error if the ID is unexpected?
+      var id = stanza.attrs.id;
+      if (id in this.iq_callbacks) {
+        this.iq_callbacks[id](stanza);
+      }
     }
   };
 
@@ -121,6 +128,9 @@ module.exports.Bot = (function() {
     this.jabber = null;
     this.keepalive = null;
     this.plugins = {};
+
+    this.iq_count = 1; // current IQ id to use
+    this.iq_callbacks = {}; // map of IQ id to callback function
 
     options = options || {};
     this.jid = options.jid;
@@ -222,6 +232,16 @@ module.exports.Bot = (function() {
     }
     this.jabber.end();
     this.emit('disconnect');
+  };
+
+  // Sends an IQ stanza and stores a callback to be called when its response
+  // is received.
+  Bot.prototype.sendIq = function(stanza, callback) {
+    stanza = stanza.root(); // work with base element
+    var id = this.iq_count++;
+    stanza.attrs.id = id;
+    this.iq_callbacks[id] = callback;
+    this.jabber.send(stanza);
   };
 
   Bot.prototype.loadPlugin = function(identifier, plugin, options) {


### PR DESCRIPTION
This makes it so Wobot fetches the room nickname it should use automatically. Users often have a hard time setting this properly or don't realize why they can't join rooms once they rename their bot. This makes things easy.

Changes of note:
- The 'connect' event is now emitted after the name has been fetched, not as soon as the client connects. Should there still be an event for when the initial connection is made?
- If there's an error fetching the profile info (HipChat server troubles) the bot just disconnects. I think this is the right behavior but I'm not sure the way I'm emitting an error and disconnecting is accurate. Can you confirm?
