### PR TITLE
Handle all stream error conditions and include text if provided.

### DIFF
--- a/examples/example1.js
+++ b/examples/example1.js
@@ -38,8 +38,8 @@ b.onDisconnect(function() {
   console.log(' -=- > Disconnect');
 });
 
-b.onError(function(error, stanza) {
-  console.log(' -=- > Error: ' + error);
+b.onError(function(error, text, stanza) {
+  console.log(' -=- > Error: ' + error + ' (' + text + ')');
 });
 
 b.onMessage(function(channel, from, message) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -9,29 +9,28 @@ var Bot;
 module.exports.Bot = (function() {
   // ##Private functions
 
-  // Whenever an XMPP error occurs, this function is responsible for triggering
-  // the `error` event with the details and disconnecting the bot from the
-  // server.
+  // Whenever an XMPP stream error occurs, this function is responsible for
+  // triggering the `error` event with the details and disconnecting the bot
+  // from the server.
+  //
+  // Stream errors (http://xmpp.org/rfcs/rfc6120.html#streams-error) look like:
+  // <stream:error>
+  //   <system-shutdown xmlns='urn:ietf:params:xml:ns:xmpp-streams'/>
+  // </stream:error>
   var onStreamError = function(error) {
     if (error instanceof xmpp.Element) {
-      var errorMessage = 'Unknown error';
-
-      if (error.getChild('see-other-host')) {
-        errorMessage = 'This account is signing in somewhere else. Maybe HipChat web version?';
-      } else {
-        var textNode = error.getChild('text');
-
-        if (textNode) {
-          errorMessage = textNode.getText();
-        }
+      var condition = error.children[0].name;
+      var text = error.getChildText('text');
+      if (!text) {
+        text = "No error text sent by HipChat, see "
+               + "http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions"
+               + " for error condition descriptions.";
       }
 
-      this.emit('error', errorMessage, error);
+      this.emit('error', condition, text, error);
     } else {
-      this.emit('error', error);
+      this.emit('error', null, null, error);
     }
-
-    this.disconnect();
   };
 
   // Helper function that overrides the XMPP `send` method to allow
@@ -71,7 +70,10 @@ module.exports.Bot = (function() {
     // load our profile to get name
     this.getProfile(function(err, data) {
       if (err) {
-        self.emit('error', 'Unable to get profile info: ' + err);
+        // This isn't technically a stream error which is what the `error`
+        // event usually represents, but we want to treat a profile fetch
+        // error as a fatal error and disconnect the bot.
+        self.emit('error', null, 'Unable to get profile info: ' + err, null);
         return;
       }
 
@@ -99,8 +101,8 @@ module.exports.Bot = (function() {
       if (stanza.getChild('delay')) return;
 
       var fromJid = new xmpp.JID(stanza.attrs.from);
-      var fromChannel = fromJid.bare().toString()
-      var fromNick = fromJid.resource
+      var fromChannel = fromJid.bare().toString();
+      var fromNick = fromJid.resource;
 
       // Ignore our own messages
       if (fromNick === this.name) return;
@@ -497,11 +499,16 @@ module.exports.Bot = (function() {
     this.on('ping', callback);
   };
 
-  // Emitted whenever an error occurs. `disconnect` will be emitted afterwards.
+  // Emitted whenever an XMPP stream error occurs. The `disconnect` event will
+  // always be emitted afterwards.
   //
-  // - `callback`: Function to be triggered: `function(message, stanza)`
-  //   - `message`: string representation of the error.
-  //   - `stanza`: instance of `xmpp.Element` (when available)
+  // Conditions are defined in the XMPP spec:
+  //   http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions
+  //
+  // - `callback`: Function to be triggered: `function(condition, text, stanza)`
+  //   - `condition`: XMPP stream error condition (string)
+  //   - `text`: Human-readable error message (string)
+  //   - `stanza`: The raw `xmpp.Element` error stanza
   Bot.prototype.onError = function(callback) {
     this.on('error', callback);
   };


### PR DESCRIPTION
Also:
- Provide a consistent set of fields to `error` event callbacks.
- Do not disconnect in onStreamError since we already disconnect on
  `error` events.
- Fix some missing semicolons.
