### PR TITLE
Explicitly request no room history when joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ Emitted whenever the bot disconnects from the server.
 
 Instances of `wobot.Bot` have the following methods:
 
-## join(roomJid)
+## join(roomJid, historyStanzas)
 Join a channel.
 
  - `roomJid` is in the following format: `????_????@conf.hipchat.com`.
+ - `historyStanzas`: Max number of history entries to request (default=0).
 
 ## part(roomJid)
 Part a channel.

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -319,9 +319,14 @@ module.exports.Bot = (function() {
   // Join the specified room.
   //
   // - `roomJid`: Target room, in the form of `????_????@conf.hipchat.com`
-  Bot.prototype.join = function(roomJid) {
+  // - `historyStanzas`: Max number of history entries to request
+  Bot.prototype.join = function(roomJid, historyStanzas) {
+    if (!historyStanzas) {
+      historyStanzas = 0;
+    }
     var packet = new xmpp.Element('presence', { to: roomJid + '/' + this.name });
-    packet.c('x', { xmlns: 'http://jabber.org/protocol/muc' });
+    packet.c('x', { xmlns: 'http://jabber.org/protocol/muc' })
+          .c('history', { xmlns: 'a', maxstanzas: String(historyStanzas) });
     this.jabber.send(packet);
   };
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -332,7 +332,10 @@ module.exports.Bot = (function() {
     }
     var packet = new xmpp.Element('presence', { to: roomJid + '/' + this.name });
     packet.c('x', { xmlns: 'http://jabber.org/protocol/muc' })
-          .c('history', { xmlns: 'a', maxstanzas: String(historyStanzas) });
+          .c('history', {
+            xmlns: 'http://jabber.org/protocol/muc',
+            maxstanzas: String(historyStanzas)
+          });
     this.jabber.send(packet);
   };
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,7 @@ module.exports.Bot = (function() {
   //
   // `options` object:
   //
-  //   - `jid`: Bot's JabberId
+  //   - `jid`: Bot's Jabber ID
   //   - `password`: Bot's HipChat password
   //   - `debug`: Set to `true` to show network debug in console
   //   - `host`: Force host to make XMPP connection to. Will look up DNS SRV
@@ -172,8 +172,14 @@ module.exports.Bot = (function() {
     this.plugins = {};
     this.iq_count = 1; // current IQ id to use
 
+    // add a JID resource if none was provided
+    var jid = new xmpp.JID(options.jid);
+    if (!jid.resource) {
+      jid.resource = 'wobot';
+    }
+
     options = options || {};
-    this.jid = options.jid;
+    this.jid = jid.toString();
     this.password = options.password;
     this.debug = options.debug;
     this.host = options.host;


### PR DESCRIPTION
We used to rely on the resource of 'bot' to prevent history from being sent but this is a more proper way and will allow other resources to be used if necessary. Special treatment of the 'bot' resource on our end is not guaranteed to stick around forever.

Also; use the resource 'wobot' if one is not provided in the initial config (something users often miss).
