### PR TITLE
Collect @mention name values for bot and users

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -79,6 +79,10 @@ module.exports.Bot = (function() {
 
       // now that we have our name we can let rooms be joined
       self.name = data.fn;
+
+      // this is the name used to @mention us
+      self.mention_name = data.nickname;
+
       self.emit('connect');
     });
   };
@@ -281,7 +285,9 @@ module.exports.Bot = (function() {
         stanza.getChild('query').getChildren('item').map(function(el) {
           rosterItems.push({
             jid: el.attrs.jid,
-            name: el.attrs.name
+            name: el.attrs.name,
+            // name used to @mention this user
+            mention_name: el.attrs.mention_name,
           });
         });
       }


### PR DESCRIPTION
Users can now pick their own @mention names, so we should know how to get them. See: http://blog.hipchat.com/2012/07/04/mentions-and-names-take-2/
