### PR TITLE
Allow explicitly setting the mucHost

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -191,7 +191,11 @@ module.exports.Bot = (function() {
 
     // Multi-User-Conference (rooms) service host. Use when directing stanzas
     // to the MUC service.
-    this.mucHost = this.host ? "conf." + this.host : "conf.hipchat.com";
+    if (options.mucHost) {
+      this.mucHost = options.mucHost;
+    } else {
+      this.mucHost = this.host ? "conf." + this.host : "conf.hipchat.com";
+    }
 
     var self = this;
     this.on('error', function(error) {


### PR DESCRIPTION
This is important for self-hosted versions of HipChat, you cannot assume the mucHost will be a combination of conf + and the host. I tried to preserve current functionality while allowing an explicit override option.
