### PR TITLE
Use node-xmpp-client module

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var events = require('events');
 var fs = require('fs');
-var xmpp = require('node-xmpp');
+var xmpp = require('node-xmpp-client');
 var bind = require('underscore').bind;
 
 var Bot;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url":"git://github.com/cjoudrey/wobot"
   },
   "dependencies": {
-    "node-xmpp": ">= 0.2.7",
+    "node-xmpp-client": "^3.0.1",
     "underscore": ">= 1.1.6"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
node-xmpp build is currently failing. node-xmpp is currently split up in to modules, we should be using the  Client module. https://github.com/node-xmpp/client
